### PR TITLE
fix:#9181 adding 'plaintext-only' to the types of contenteditable

### DIFF
--- a/packages/svelte/elements.d.ts
+++ b/packages/svelte/elements.d.ts
@@ -486,7 +486,7 @@ export interface HTMLAttributes<T extends EventTarget> extends AriaAttributes, D
 	accesskey?: string | undefined | null;
 	autofocus?: boolean | undefined | null;
 	class?: string | undefined | null;
-	contenteditable?: Booleanish | 'inherit' | undefined | null;
+	contenteditable?: Booleanish | 'inherit' | 'plaintext-only' | undefined | null;
 	contextmenu?: string | undefined | null;
 	dir?: string | undefined | null;
 	draggable?: Booleanish | undefined | null;


### PR DESCRIPTION
fix:#9181 
by adding a type in contenteditable